### PR TITLE
Added Redmine integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+/config.yaml
+/team.yaml

--- a/config_sample.yaml
+++ b/config_sample.yaml
@@ -16,3 +16,7 @@ label_check: false
 project: <Project Name>
 url: <Jira URL>
 verify_ssl: true
+redmine_url: <redmine_url>
+redmine_task_prefix: <redmine task prefix>
+redmine_username: <redmine api username/email>
+redmine_password: <redmine password>

--- a/jirasync.py
+++ b/jirasync.py
@@ -18,6 +18,9 @@ from utils.utils import (
 from plugins.github import (
     GitHubPlugin,
 )
+from plugins.redmine import (
+    RedminePlugin,
+)
 
 
 class Config(object):
@@ -299,10 +302,38 @@ def start_syncing_team(config, interval):
             )
 
 
-
-
-
-
+@cli.command()
+@click.option(
+    '--sync',
+    default=False,
+    is_flag=True,
+    help="if not provided will only print"
+)
+@pass_config
+def redmine(config, sync):
+    teams = get_yaml_data(config.team_file)
+    config_data = get_yaml_data(config.config_file)
+    redmine_plugin = RedminePlugin(
+        config_data['redmine_url'],
+        config_data['redmine_username'],
+        config_data['redmine_password'],
+        config_data['redmine_task_prefix'],
+        sync=sync,
+        jira=MyJiraWrapper('config.yaml', 'labels.yaml')
+    )
+    for team in teams:
+        click.echo("For Team ==> {}".format(team))
+        users = teams[team]['Users']
+        for user in users:
+            redmine_userid = users[user].get('redmine_userid')
+            jira_username = users[user].get('jira_username')
+            if not redmine_userid:
+                click.echo(
+                    "User {0} has no redmine configuration.".format(user)
+                )
+                continue
+            click.echo("For User ==> {0}:{1}".format(user, redmine_userid))
+            redmine_plugin.process_issues(redmine_userid, jira_username)
 
 
 

--- a/jirasync.py
+++ b/jirasync.py
@@ -307,10 +307,22 @@ def start_syncing_team(config, interval):
     '--sync',
     default=False,
     is_flag=True,
-    help="if not provided will only print"
+    help="Perform the writes to Jira"
 )
 @pass_config
 def redmine(config, sync):
+    """Reads issues from redmine for users defined on `team.yaml` and sync
+    with Jira. By default runs in a `check only` mode (no write is performed)
+    to write to jira add `--sync` to the command line.
+
+    Expects Redmine and Jira config on `config.yaml` and users information on
+    `team.yaml`. See `team_sample.yaml` and `config_sample.yaml` for examples.
+    """
+    if not sync:
+        echo_error(
+            "Running on check-only mode, to write to Jira add `--sync` "
+            "to the command line"
+        )
     teams = get_yaml_data(config.team_file)
     config_data = get_yaml_data(config.config_file)
     redmine_plugin = RedminePlugin(
@@ -334,19 +346,3 @@ def redmine(config, sync):
                 continue
             click.echo("For User ==> {0}:{1}".format(user, redmine_userid))
             redmine_plugin.process_issues(redmine_userid, jira_username)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/plugins/redmine.py
+++ b/plugins/redmine.py
@@ -1,0 +1,128 @@
+from redminelib import Redmine
+from utils.utils import echo, echo_error, echo_success
+
+
+class RedminePlugin(object):
+    def __init__(
+        self,
+        redmine_url,
+        redmine_username,
+        redmine_password,
+        redmine_task_prefix=None,
+        sync=False,
+        jira=None
+    ):
+        self.redmine = Redmine(
+            redmine_url,
+            username=redmine_username,
+            password=redmine_password
+        )
+        self.redmine_task_prefix = redmine_task_prefix
+        self.sync = sync
+        self.jira = jira
+
+    def get_issues(self, redmine_userid):
+        user = self.redmine.user.get(redmine_userid)
+
+        open_issues = list(
+            self.redmine.issue.filter(assigned_to_id=user.id, status_id='open')
+        )
+        closed_issues = list(
+            self.redmine.issue.filter(
+                assigned_to_id=user.id,
+                status_id='closed'
+            )
+        )
+        all_issues = open_issues + closed_issues
+
+        return {
+            'open': open_issues,
+            'closed': closed_issues,
+            'all': all_issues
+        }
+
+    def do_sync(self, issue, jira_username):
+        """
+        [u'assigned_to',
+        u'attachments',
+        u'author',
+        u'changesets',
+        u'children',
+        u'closed_on',
+        u'created_on',
+        u'custom_fields',
+        u'description',
+        u'done_ratio',
+        u'id',
+        u'journals',
+        u'priority',
+        u'project',
+        u'relations',
+        u'status',
+        u'subject',
+        u'time_entries',
+        u'tracker',
+        u'updated_on',
+        u'watchers']
+        """
+        if not self.jira:
+            echo_error("Jira Wrapper is not Available")
+            return
+        # build the unique issue_text prefix
+        issue_text = '{prefix}#{issue.project}#{issue.id}'.format(
+            prefix=self.redmine_task_prefix,
+            issue=issue
+        )
+        echo("Searching Jira for {0}".format(issue_text))
+        # check if it already exists
+        tasks = self.jira.search_task_by_summary(text=issue_text)
+        task_count = len(tasks)
+        if task_count > 1:
+            echo_error("Duplicated task found for {0}".format(issue_text))
+        elif task_count == 1:
+            # update existing issue
+            self.update_task(tasks[0], issue, jira_username)
+        else:
+            # create a new assigned issue in backlog
+            self.create_task(issue, issue_text, jira_username)
+
+    def update_task(self, task, issue, jira_username):
+        echo('Updating existing task {0}'.format(task))
+        if self.sync:
+            # FIXME: Implement the update
+            pass
+
+    def create_task(self, issue, issue_text, jira_username):
+        echo("Creating a new task on Jira for {0}".format(issue_text))
+        params = {
+            'summary': "{}#{} -{}".format(
+                issue_text,
+                jira_username,
+                issue.subject
+            ),
+            'details': "{}".format(issue.description),
+            'component': 'Automation',
+            'labels': ['Automation', self.redmine_task_prefix],
+            'sprint': 'backlog',
+            'assignee': jira_username,  # FIXME
+            'issuetype': 'Task',
+        }
+        if self.sync:
+            created_issue = self.jira.create_issue(**params)
+            echo_success(
+                "Created Jira ............{}/browse/{}".format(
+                    self.jira.jira_url,
+                    created_issue.key.encode()
+                )
+            )
+
+    def process_issues(self, redmine_userid, jira_username):
+        issues = self.get_issues(redmine_userid)
+        if not jira_username:
+            jira_username = self.jira.userid.encode()
+        for issue in issues['all']:
+            echo(
+                "Processing: {issue}:{issue.id} - status: {issue.status}"
+                .format(issue=issue)
+            )
+            self.do_sync(issue, jira_username)

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,3 +40,4 @@ undecorated==0.3.0
 urllib3==1.24.2
 wcwidth==0.1.7
 yamlordereddictloader==0.4.0
+python-redmine==2.2.1

--- a/team_sample.yaml
+++ b/team_sample.yaml
@@ -22,9 +22,15 @@ PulpQE:
     github_token: <Git Hub Token>
     Users:
     #you can write all the users in mentioned below way
-      Omkar Khatavkar:
-        github_username: omkarkhatavkar
-        jira_username: okhatavk
-      Jitendra Yejare:
-        github_username: jyejare
-        jira_username: jyejare
+      Bruno Rocha:
+        github_username: rochacbruno
+        jira_username: brocha
+        redmine_userid: 13998
+      Brian herring:
+        github_username: bherrin3
+        jira_username: bherring
+        redmine_userid: 14217
+      Kersom Moura:
+        github_username: kersommoura
+        jira_username: kersom
+        redmine_userid: 13606

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,16 +5,21 @@ import os
 from datetime import datetime, timedelta
 
 
+def echo(msg):
+    """Just a wrapper to enable overloading and mocking"""
+    click.echo(msg)
+
+
 def echo_success(msg):
-    click.echo(click.style(msg, fg='green'))
+    echo(click.style(msg, fg='green'))
 
 
 def echo_error(msg):
-    click.echo(click.style(msg, fg='red'))
+    echo(click.style(msg, fg='red'))
 
 
 def echo_skip(msg):
-    click.echo(click.style(msg, fg='cyan'))
+    echo(click.style(msg, fg='cyan'))
 
 
 def update_yaml(file_name, content):

--- a/wrappers/jirawrapper.py
+++ b/wrappers/jirawrapper.py
@@ -49,10 +49,12 @@ class MyJiraWrapper(JiraWrapper):
         if assignee:
             self.jira.assign_issue(new_issue.key, assignee)
 
-        if sprint == "backlog":
-            self.jira.move_to_backlog([new_issue.key])
-        else:
-            self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
+        # FIXME: Uncomment after testing, this was disabled because of
+        #        containerized Jira has no scrum plugin.
+        # if sprint == "backlog":
+        #     self.jira.move_to_backlog([new_issue.key])
+        # else:
+        #     self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
 
         return new_issue
 

--- a/wrappers/jirawrapper.py
+++ b/wrappers/jirawrapper.py
@@ -49,12 +49,10 @@ class MyJiraWrapper(JiraWrapper):
         if assignee:
             self.jira.assign_issue(new_issue.key, assignee)
 
-        # FIXME: Uncomment after testing, this was disabled because of
-        #        containerized Jira has no scrum plugin.
-        # if sprint == "backlog":
-        #     self.jira.move_to_backlog([new_issue.key])
-        # else:
-        #     self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
+        if sprint == "backlog":
+            self.jira.move_to_backlog([new_issue.key])
+        else:
+            self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
 
         return new_issue
 

--- a/wrappers/jirawrapper.py
+++ b/wrappers/jirawrapper.py
@@ -49,10 +49,14 @@ class MyJiraWrapper(JiraWrapper):
         if assignee:
             self.jira.assign_issue(new_issue.key, assignee)
 
-        if sprint == "backlog":
-            self.jira.move_to_backlog([new_issue.key])
-        else:
-            self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
+        try:
+            if sprint == "backlog":
+                self.jira.move_to_backlog([new_issue.key])
+            else:
+                self.jira.add_issues_to_sprint(sprint_id, [new_issue.key])
+        except IndexError:
+            # Some Jira installations have no Scrum plugin so no backlog exists
+            pass
 
         return new_issue
 


### PR DESCRIPTION
Included `jirasync redmine --sync` command
Syncing redmine issues using `python-redmine` library.

> Tried the implementation using `did` but it does not fetch data from the newest redmine API, it includes only a subset of fields and it is not possible for example to get the issue status.
> So used `python-redmine` to talk to redmine API.

```bash
$ jirasync redmine --help
Usage: jirasync redmine [OPTIONS]

  Reads issues from redmine for users defined on `team.yaml` and sync with
  Jira. By default runs in a `check only` mode (no write is performed) to
  write to jira add `--sync` to the command line.

  Expects Redmine and Jira config on `config.yaml` and users information on
  `team.yaml`. See `team_sample.yaml` and `config_sample.yaml` for examples.

Options:
  --sync  Perform the writes to Jira
  --help  Show this message and exit.
```

Then

```bash
$ jirasync redmine --sync
For Team ==> PulpQE
For User ==> Admin:1
# A total of 3 issues to process.

## Processing: Now it works well:4 - status: open
Connecting to jira at http://localhost:8080
Using basic authentication
Warning: SSL certificate verification is disabled!
Searching Jira for redmine#pulp#4# using query [project = 10000 AND status != Done AND assignee = brocha AND summary ~ \"redmine\u0023pulp\u00234\u0023\"]
Found 0: []
Created Jira redmine#pulp#4#...http://localhost:8080/browse/SATQE-53

## Processing: the last one:3 - status: closed
Searching Jira for redmine#pulp#3# using query [project = 10000 AND status != Done AND assignee = brocha AND summary ~ \"redmine\u0023pulp\u00233\u0023\"]
Found 1: [<JIRA Issue: key=u'SATQE-52', id=u'10051'>]
Updated status of SATQE-52/redmine#pulp#3#[closed] ...http://localhost:8080/browse/SATQE-52

## Processing: test 1:1 - status: closed
Searching Jira for redmine#pulp#1# using query [project = 10000 AND status != Done AND assignee = brocha AND summary ~ \"redmine\u0023pulp\u00231\u0023\"]
Found 0: []
Issue 1 is closed on redmine, skipping

```
