### PR TITLE
Fix #5 make config file search to look env var and XDG dirs

### DIFF
--- a/jirasync.py
+++ b/jirasync.py
@@ -1,6 +1,11 @@
+# coding: utf-8
 import click
 import os
+import time
+
 from passlib.context import CryptContext
+from xdg import BaseDirectory
+
 from wrappers.jirawrapper import MyJiraWrapper
 from plugins.jira_workflow import (
     start_issue_workflow,
@@ -21,18 +26,56 @@ from plugins.github import (
 from plugins.redmine import (
     RedminePlugin,
 )
-import time
 
 
 class Config(object):
 
     def __init__(self):
-        self.config_file = "config.yaml"
+        self.config_file = self.get_config_file("config.yaml")
         self.pwd_context = CryptContext(
             schemes=["pbkdf2_sha256"],
             default="pbkdf2_sha256",
             pbkdf2_sha256__default_rounds=30000
         )
+
+    def get_config_file(self, filename):
+        """Look for the proper config file path based on
+        https://github.com/omkarkhatavkar/jirasync/issues/5
+        """
+        # Try to find the file from path exported to JIRASYNC_SETTINGS_PATH
+        # this variable can be a directory path like /foo/bar
+        # and also can be full path like /etc/foo/config.yaml
+        path = os.environ.get('JIRASYNC_SETTINGS_PATH')
+        if path is not None:
+            if not path.endswith(("yaml", "yml")):
+                path = os.path.join(path, filename)
+            if os.path.exists(path):
+                echo_success("Found config file in {}".format(path))
+                return path
+            else:
+                echo_error(
+                    "JIRASYNC_SETTINGS_PATH={0} cannot be found"
+                    .format(path)
+                )
+
+        # Try to find in the XDG paths
+        # look ~/.config/jirasync/config.yaml
+        # then /etc/xdg/jirasync/config.yaml
+        # then /etc/jirasync/config.yaml
+        BaseDirectory.xdg_config_dirs.append('/etc')
+        for dir_ in BaseDirectory.load_config_paths("jirasync"):
+            path = os.path.join(dir_, filename)
+            if os.path.exists(path):
+                echo_success("Found config file in {}".format(path))
+                return path
+
+        # load from current directory
+        path = os.path.join(os.curdir, filename)
+        if os.path.exists(path):
+            echo_success("Found config file in {}".format(path))
+            return path
+
+        raise IOError("{0} cannot be found".format(path))
 
 
 pass_config = click.make_pass_decorator(Config, ensure=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ urllib3==1.24.2
 wcwidth==0.1.7
 yamlordereddictloader==0.4.0
 python-redmine==2.2.1
+pyxdg==0.26


### PR DESCRIPTION
## Env var
Try to find the file from path exported to `JIRASYNC_SETTINGS_PATH`
this variable can be a directory path like `/foo/bar`
and also can be full path like `/etc/foo/config.yaml`

## XDG
Try to find in the XDG paths
look `~/.config/jirasync/config.yaml`
then `/etc/xdg/jirasync/config.yaml`
then `/etc/jirasync/config.yaml`

## Local dir
Finally try to load from current directory.

## Fail
Or raise IoError.