### PR TITLE
Fix search query to not filter by status

### DIFF
--- a/wrappers/jirawrapper.py
+++ b/wrappers/jirawrapper.py
@@ -78,19 +78,20 @@ class MyJiraWrapper(JiraWrapper):
         if None not in (current_sprint_id, issue.key):
             self.jira.add_issues_to_sprint(current_sprint_id, issue.key)
 
-    def search_existing_task(self, issue_text, assignee=None):
+    def search_existing_task(self, issue_text, assignee=None, only_open=False):
         # check if it already exists
         search_query = (
-            'project = {} '
-            'AND status != Done '
-            'AND summary ~ \\"{}\\"'
+            'project = {} AND summary ~ \\"{}\\"'
         ).format(
-            self.project_id,
-            issue_text.replace('#', '\u0023')
+            self.project_id, issue_text.replace('#', '\u0023')
         )
 
         if assignee is not None:
             search_query += " AND assignee = {}".format(assignee)
+
+        if only_open:
+            search_query += " AND status != Done "
+
         echo(
             "Searching Jira for {0} using query [{1}]".format(
                 issue_text, search_query


### PR DESCRIPTION
While testing to figure out the cases for #15
I figured out that we cannot use the fragment `AND status != Done`
for all the quueries because once a task is done, in the next run
Jirasync will create a new task for it and we will end with duplicates.

So I removed that fragment from the search query and tested all
the workflows described on #15