### PR TITLE
added monit script to monitor and alert jira-sync service

### DIFF
--- a/monit/jirasync_monit.conf
+++ b/monit/jirasync_monit.conf
@@ -1,0 +1,9 @@
+set daemon 60 #check services ever 60 seconds
+set logfile /var/log/monit.log
+
+check process jirasync with match jirasync every 1 cycles
+    start program = "/usr/bin/systemctl start jirasync.service" with timeout 30 seconds
+    stop program = "/usr/bin/systemctl stop jirasync.service"
+    if 2 restarts within 4 cycle
+        then exec "/bin/bash -c /etc/jirasync/send_email.sh"
+    if 4 restarts within 6 cycles then timeout

--- a/monit/monit.sh
+++ b/monit/monit.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+yum -y install monit
+systemctl enable monit
+BASEDIR=$(dirname "$0")
+cp $BASEDIR/send_email.sh /etc/jirasync
+chmod +x /etc/jirasync/send_email.sh
+cp $BASEDIR/jirasync_monit.conf /etc/monit.d/
+systemctl restart monit
+monit -t

--- a/monit/send_email.sh
+++ b/monit/send_email.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+subject="Alert: jirasync is restarted multiple times "
+hostname=$(hostname)
+body="jirasync is restarted multiple times on $hostname"
+from="okhatavk@redhat.com"
+to="okhatavk@redhat.com, brocha@redhat.com"
+echo -e "Subject:${subject}\n${body}" | sendmail -f "${from}" -t "${to}"


### PR DESCRIPTION
### PR objective
Added monit script to monitor and alert the jirasync process Issue #19 

### How to test

- Run the monit shell script 

```
root@okhatavk jirasync]# sh monit/monit.sh 
Loaded plugins: changelog, fs-snapshot, priorities, product-id, refresh-packagekit, rhnplugin, rpm-warm-cache, search-disabled-repos,
              : subscription-manager, verify
This system is receiving updates from RHN Classic or Red Hat Satellite.
Repository google-chrome is listed more than once in the configuration
666 packages excluded due to repository priority protections
Package monit-5.25.1-1.el7.x86_64 already installed and latest version
Nothing to do
Control file syntax OK
(env) [root@okhatavk jirasync]# 

```

- Check monit log  
```
(env) [root@okhatavk jirasync]# tail -f /var/log/monit.log 
[IST Aug 11 14:42:06] info     : Starting Monit 5.25.1 daemon
```

- Stop Jirasync multiple cycles and email will be received.  